### PR TITLE
fixed to update orientation after session setup

### DIFF
--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -94,7 +94,6 @@
   [self checkDeviceAuthorizationStatus];
 
   dispatch_async(dispatch_get_main_queue(), ^{
-  AVCaptureVideoOrientation currentOrientation = [self getCurrentOrientation];
   dispatch_async(self.sessionQueue, ^{
       NSError *error = nil;
       BOOL success = TRUE;
@@ -147,10 +146,12 @@
         [self.session addOutput:dataOutput];
       }
 
-      [self updateOrientation:currentOrientation];
       self.device = videoDevice;
 
       [self.session startRunning];
+      
+      AVCaptureVideoOrientation currentOrientation = [self getCurrentOrientation];
+      [self updateOrientation:currentOrientation];
 
       completion(success, videoDevice);
   });
@@ -181,7 +182,6 @@
   }
 
   dispatch_async(dispatch_get_main_queue(), ^{
-  AVCaptureVideoOrientation currentOrientation = [self getCurrentOrientation];
   dispatch_async([self sessionQueue], ^{
       NSError *error = nil;
       BOOL success = TRUE;
@@ -219,11 +219,13 @@
         [self setVideoDeviceInput:videoDeviceInput];
       }
 
-      [self updateOrientation:currentOrientation];
       [self.session commitConfiguration];
       self.device = videoDevice;
 
       [self.session startRunning];
+
+      AVCaptureVideoOrientation currentOrientation = [self getCurrentOrientation];
+      [self updateOrientation:currentOrientation];
 
       completion(success);
   });


### PR DESCRIPTION
https://easymerch.bitrix24.ru/workgroups/group/235/tasks/task/view/65035/

При перезапуске камеры [self updateOrientation:currentOrientation] запускался с устаревшим значением currentOrientation из-за лага прогрузки. Переместил обновление ориентации превью после запуска камеры. Это работает и мы получаем актуальное значение.